### PR TITLE
Fix Procfile to use 'imgret' directly instead of './imgret'

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./imgret -bind=:$PORT
+web: imgret -bind=:$PORT


### PR DESCRIPTION
The binary should be available on PATH, not as a relative path.

🤖 Generated with [Claude Code](https://claude.ai/code)